### PR TITLE
feat: implement interactive pLDDT Recharts visualization and sequence validation

### DIFF
--- a/frontend/TESTING_GUIDE.md
+++ b/frontend/TESTING_GUIDE.md
@@ -15,16 +15,19 @@ We use the modern Vite testing ecosystem:
 ## How to Run the Tests
 
 To run the entire test suite once:
+
 ```bash
 npm run test
 ```
 
 To run tests in **Watch Mode** (automatically re-runs tests when you save a file):
+
 ```bash
 npm run test:watch
 ```
 
 To enforce code style alongside your tests:
+
 ```bash
 npm run lint      # Checks for code issues
 npm run format    # Auto-formats code with Prettier
@@ -46,19 +49,13 @@ import userEvent from '@testing-library/user-event';
 import SequenceInput from '../components/SequenceInput';
 
 describe('SequenceInput Component', () => {
-
   // 1. Testing simple rendering
   it('renders correctly', () => {
     // Render the component with some mock props
     render(
-      <SequenceInput 
-        sequence="" 
-        setSequence={() => {}} 
-        onPredict={() => {}} 
-        status="ready" 
-      />
+      <SequenceInput sequence="" setSequence={() => {}} onPredict={() => {}} status="ready" />
     );
-    
+
     // Check if what the user sees is on screen
     expect(screen.getByPlaceholderText(/Paste your amino-acid sequence/i)).toBeInTheDocument();
   });
@@ -69,18 +66,18 @@ describe('SequenceInput Component', () => {
     const user = userEvent.setup(); // Setup user interaction
 
     render(
-      <SequenceInput 
-        sequence="ARNDCQEGHILKMFPSTWYV" 
-        setSequence={() => {}} 
-        onPredict={mockPredict} 
-        status="ready" 
+      <SequenceInput
+        sequence="ARNDCQEGHILKMFPSTWYV"
+        setSequence={() => {}}
+        onPredict={mockPredict}
+        status="ready"
       />
     );
-    
+
     // Find the button and click it
     const btn = screen.getByRole('button', { name: /Predict/i });
     await user.click(btn);
-    
+
     // Assert the function was called!
     expect(mockPredict).toHaveBeenCalled();
   });
@@ -88,5 +85,6 @@ describe('SequenceInput Component', () => {
 ```
 
 ### Best Practices
+
 - **Query by Accessibility**: Prefer `getByRole`, `getByLabelText`, and `getByText`. Avoid querying by CSS classes, as tests should test functionality, not DOM structure.
 - **Mock External Hooks**: If your component relies on global states (like `useAuth`), mock the hook using `vi.spyOn(AuthProvider, 'useAuth')` so you can test the component in isolation.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,7 +13,8 @@
         "chart.js": "^4.5.1",
         "react": "^19.2.0",
         "react-chartjs-2": "^5.3.1",
-        "react-dom": "^19.2.0"
+        "react-dom": "^19.2.0",
+        "recharts": "^3.8.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -133,6 +134,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -495,6 +497,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -543,6 +546,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1272,6 +1276,42 @@
       "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
       "license": "MIT"
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
@@ -1633,7 +1673,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@supabase/auth-js": {
@@ -1811,8 +1856,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1870,6 +1914,69 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -1910,8 +2017,9 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1922,9 +2030,16 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -2091,6 +2206,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2131,7 +2247,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2240,6 +2355,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2317,11 +2433,21 @@
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
       "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
       "engines": {
         "pnpm": ">=8"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/color-convert": {
@@ -2398,8 +2524,129 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/data-urls": {
       "version": "7.0.0",
@@ -2440,6 +2687,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2462,8 +2715,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.302",
@@ -2491,6 +2743,16 @@
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
+      "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -2563,6 +2825,7 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2766,6 +3029,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/expect-type": {
       "version": "1.3.0",
@@ -2977,6 +3246,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -3012,6 +3291,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/iobuffer": {
@@ -3238,7 +3526,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -3465,6 +3752,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3533,7 +3821,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -3549,7 +3836,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -3572,6 +3858,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3591,6 +3878,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3602,9 +3890,32 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -3614,6 +3925,36 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.0.tgz",
+      "integrity": "sha512-Z/m38DX3L73ExO4Tpc9/iZWHmHnlzWG4njQbxsF5aSjwqmHNDDIm0rdEBArkwsBvR8U6EirlEHiQNYWCVh9sGQ==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/redent": {
@@ -3630,6 +3971,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -3639,6 +3996,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -3824,6 +4187,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -4005,12 +4374,44 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
+    },
     "node_modules/vite": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4317,6 +4718,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,8 @@
     "chart.js": "^4.5.1",
     "react": "^19.2.0",
     "react-chartjs-2": "^5.3.1",
-    "react-dom": "^19.2.0"
+    "react-dom": "^19.2.0",
+    "recharts": "^3.8.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/frontend/src/components/PldtMetrics.jsx
+++ b/frontend/src/components/PldtMetrics.jsx
@@ -1,83 +1,66 @@
 import { useMemo } from 'react';
-import { Line } from 'react-chartjs-2';
 import {
-  Chart as ChartJS,
-  CategoryScale,
-  LinearScale,
-  PointElement,
-  LineElement,
-  Filler,
-  Tooltip,
-} from 'chart.js';
-
-ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Filler, Tooltip);
+  ResponsiveContainer,
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip as RechartsTooltip,
+} from 'recharts';
 
 export default function PldtMetrics({ plddtData, sequence }) {
   const mean = plddtData?.mean ?? null;
+  const perResidue = plddtData?.per_residue || [];
+  const sequenceLength = sequence?.length || 0;
+  
+  const isValidated = perResidue.length > 0 && perResidue.length === sequenceLength;
 
   const chartData = useMemo(() => {
-    const perResidue = plddtData?.per_residue || [];
-    if (!perResidue.length) return null;
+    if (!perResidue.length) return [];
+    return perResidue.map((val, i) => {
+      let conf = 'Very Low';
+      if (val > 90) conf = 'Very High';
+      else if (val > 70) conf = 'Confident';
+      else if (val > 50) conf = 'Low';
 
-    // Down-sample if too many residues for readability
-    const step = Math.max(1, Math.floor(perResidue.length / 80));
-    const sampled = perResidue.filter((_, i) => i % step === 0);
-    const labels = sampled.map((_, i) => (i * step + 1).toString());
+      return {
+        residueIndex: i + 1,
+        plddt: val,
+        aminoAcid: sequence?.[i] || '?',
+        confidence: conf,
+      };
+    });
+  }, [perResidue, sequence]);
 
-    return {
-      labels,
-      datasets: [
-        {
-          data: sampled,
-          borderColor: '#1B2559',
-          backgroundColor: 'rgba(27, 37, 89, 0.06)',
-          borderWidth: 1.5,
-          pointRadius: 0,
-          fill: true,
-          tension: 0.3,
-        },
-      ],
-    };
-  }, [plddtData?.per_residue]);
-
-  const chartOptions = {
-    responsive: true,
-    maintainAspectRatio: false,
-    plugins: {
-      tooltip: {
-        callbacks: {
-          label: (ctx) => {
-            const val = ctx.parsed.y;
-            const residueIdx = parseInt(ctx.label) - 1;
-            const aa = sequence?.[residueIdx] || '';
-            const conf =
-              val > 90 ? 'Very High' : val > 70 ? 'Confident' : val > 50 ? 'Low' : 'Very Low';
-            return [`pLDDT: ${val.toFixed(1)} (${conf})`, aa ? `Amino Acid: ${aa}` : ''].filter(
-              Boolean
-            );
-          },
-          title: (items) => `Residue ${items[0]?.label}`,
-        },
-      },
-    },
-    scales: {
-      x: {
-        display: false,
-      },
-      y: {
-        display: true,
-        min: 0,
-        max: 100,
-        ticks: {
-          font: { size: 10, family: 'Inter' },
-          color: '#A3AED0',
-          stepSize: 25,
-        },
-        grid: {
-          color: '#E9EDF722',
-        },
-      },
-    },
+  const CustomTooltip = ({ active, payload }) => {
+    if (active && payload && payload.length) {
+      const data = payload[0].payload;
+      return (
+        <div style={{
+          background: '#fff',
+          border: '1px solid #E9EDF7',
+          padding: '8px 12px',
+          borderRadius: 8,
+          boxShadow: '0 4px 12px rgba(0,0,0,0.05)',
+          fontSize: 13,
+          color: 'var(--navy)',
+          fontFamily: 'Inter, sans-serif'
+        }}>
+          <div style={{ fontWeight: 600, marginBottom: 4 }}>Residue {data.residueIndex}</div>
+          <div>Amino Acid: <strong>{data.aminoAcid}</strong></div>
+          <div>pLDDT: <strong>{typeof data.plddt === 'number' ? data.plddt.toFixed(2) : data.plddt}</strong></div>
+          <div style={{ 
+            color: data.plddt > 90 ? '#05cd99' : data.plddt > 70 ? '#4318FF' : data.plddt > 50 ? '#FFCE20' : '#EE5D50',
+            fontWeight: 500,
+            marginTop: 4
+          }}>
+            {data.confidence}
+          </div>
+        </div>
+      );
+    }
+    return null;
   };
 
   return (
@@ -91,25 +74,39 @@ export default function PldtMetrics({ plddtData, sequence }) {
             ❤️
           </span>
           pLDDT Score
-          <span style={{ fontSize: 12, color: 'var(--text-muted)', fontWeight: 400 }}>ⓘ</span>
+          <span style={{ fontSize: 12, color: 'var(--text-muted)', fontWeight: 400, marginLeft: 4 }}>ⓘ</span>
         </div>
         <div className="card__actions">
-          <button className="card__action-btn" title="Calendar">
-            📅
-          </button>
-          <button className="card__action-btn" title="More">
-            ⋮
-          </button>
+          <button className="card__action-btn" title="Calendar">📅</button>
+          <button className="card__action-btn" title="More">⋮</button>
         </div>
       </div>
 
       <div className="card__body">
-        <p
-          style={{ fontSize: 13, color: 'var(--text-secondary)', marginBottom: 'var(--space-sm)' }}
-        >
-          <strong>pLDDT Analysis</strong>
-        </p>
-        <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, marginBottom: 4 }}>
+        {/* Validation Check */}
+        {perResidue.length > 0 && (
+          <div style={{ 
+            display: 'flex', 
+            alignItems: 'center', 
+            gap: 6, 
+            marginBottom: 12,
+            padding: '8px 12px',
+            background: isValidated ? 'rgba(5, 205, 153, 0.1)' : 'rgba(238, 93, 80, 0.1)',
+            borderRadius: 6,
+            color: isValidated ? 'var(--success)' : 'var(--danger)',
+            fontSize: 13,
+            fontWeight: 500
+          }}>
+            <span>{isValidated ? '✓' : '⚠️'}</span>
+            <span>
+              {isValidated 
+                ? `Validation Passed: PDB array size (${perResidue.length}) matches sequence length (${sequenceLength}).`
+                : `Validation Failed: PDB array size (${perResidue.length}) does not match sequence length (${sequenceLength}).`}
+            </span>
+          </div>
+        )}
+
+        <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, marginBottom: 12 }}>
           <span style={{ fontSize: 13, color: 'var(--text-secondary)' }}>
             The average confidence score is
           </span>
@@ -127,10 +124,44 @@ export default function PldtMetrics({ plddtData, sequence }) {
           </span>
         </div>
 
-        {/* Sparkline chart */}
-        {chartData ? (
-          <div className="plddt-metrics__chart">
-            <Line data={chartData} options={chartOptions} />
+        {/* Recharts Area Chart */}
+        {chartData.length > 0 ? (
+          <div className="plddt-metrics__chart" style={{ height: 280, width: '100%', marginTop: 20 }}>
+            <ResponsiveContainer width="100%" height="100%">
+              <AreaChart data={chartData} margin={{ top: 5, right: 0, left: -20, bottom: 0 }}>
+                <defs>
+                  <linearGradient id="colorPlddt" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="5%" stopColor="#1B2559" stopOpacity={0.3} />
+                    <stop offset="95%" stopColor="#1B2559" stopOpacity={0.0} />
+                  </linearGradient>
+                </defs>
+                <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="#E9EDF7" />
+                <XAxis 
+                  dataKey="residueIndex" 
+                  tick={{ fontSize: 10, fill: '#A3AED0' }} 
+                  axisLine={false} 
+                  tickLine={false}
+                  minTickGap={20}
+                />
+                <YAxis 
+                  domain={[0, 100]} 
+                  ticks={[0, 25, 50, 75, 100]}
+                  tick={{ fontSize: 10, fill: '#A3AED0' }} 
+                  axisLine={false} 
+                  tickLine={false}
+                />
+                <RechartsTooltip content={<CustomTooltip />} />
+                <Area 
+                  type="monotone" 
+                  dataKey="plddt" 
+                  stroke="#1B2559" 
+                  strokeWidth={2}
+                  fillOpacity={1} 
+                  fill="url(#colorPlddt)" 
+                  activeDot={{ r: 4, strokeWidth: 0, fill: '#4318FF' }}
+                />
+              </AreaChart>
+            </ResponsiveContainer>
           </div>
         ) : (
           <div
@@ -141,13 +172,14 @@ export default function PldtMetrics({ plddtData, sequence }) {
               justifyContent: 'center',
               color: 'var(--text-muted)',
               fontSize: 13,
+              height: 200
             }}
           >
-            No data yet
+             No data yet
           </div>
         )}
 
-        <p className="plddt-metrics__desc">
+        <p className="plddt-metrics__desc" style={{ marginTop: 16 }}>
           pLDDT is a per-residue confidence estimate (0-100). Scores above 90 indicate very high
           confidence; 70-90 suggests a generally reliable backbone prediction.
         </p>

--- a/frontend/src/components/PldtMetrics.jsx
+++ b/frontend/src/components/PldtMetrics.jsx
@@ -9,11 +9,57 @@ import {
   Tooltip as RechartsTooltip,
 } from 'recharts';
 
+const CustomTooltip = ({ active, payload }) => {
+  if (active && payload && payload.length) {
+    const data = payload[0].payload;
+    return (
+      <div
+        style={{
+          background: '#fff',
+          border: '1px solid #E9EDF7',
+          padding: '8px 12px',
+          borderRadius: 8,
+          boxShadow: '0 4px 12px rgba(0,0,0,0.05)',
+          fontSize: 13,
+          color: 'var(--navy)',
+          fontFamily: 'Inter, sans-serif',
+        }}
+      >
+        <div style={{ fontWeight: 600, marginBottom: 4 }}>Residue {data.residueIndex}</div>
+        <div>
+          Amino Acid: <strong>{data.aminoAcid}</strong>
+        </div>
+        <div>
+          pLDDT:{' '}
+          <strong>{typeof data.plddt === 'number' ? data.plddt.toFixed(2) : data.plddt}</strong>
+        </div>
+        <div
+          style={{
+            color:
+              data.plddt > 90
+                ? '#05cd99'
+                : data.plddt > 70
+                  ? '#4318FF'
+                  : data.plddt > 50
+                    ? '#FFCE20'
+                    : '#EE5D50',
+            fontWeight: 500,
+            marginTop: 4,
+          }}
+        >
+          {data.confidence}
+        </div>
+      </div>
+    );
+  }
+  return null;
+};
+
 export default function PldtMetrics({ plddtData, sequence }) {
   const mean = plddtData?.mean ?? null;
-  const perResidue = plddtData?.per_residue || [];
+  const perResidue = useMemo(() => plddtData?.per_residue || [], [plddtData?.per_residue]);
   const sequenceLength = sequence?.length || 0;
-  
+
   const isValidated = perResidue.length > 0 && perResidue.length === sequenceLength;
 
   const chartData = useMemo(() => {
@@ -33,36 +79,6 @@ export default function PldtMetrics({ plddtData, sequence }) {
     });
   }, [perResidue, sequence]);
 
-  const CustomTooltip = ({ active, payload }) => {
-    if (active && payload && payload.length) {
-      const data = payload[0].payload;
-      return (
-        <div style={{
-          background: '#fff',
-          border: '1px solid #E9EDF7',
-          padding: '8px 12px',
-          borderRadius: 8,
-          boxShadow: '0 4px 12px rgba(0,0,0,0.05)',
-          fontSize: 13,
-          color: 'var(--navy)',
-          fontFamily: 'Inter, sans-serif'
-        }}>
-          <div style={{ fontWeight: 600, marginBottom: 4 }}>Residue {data.residueIndex}</div>
-          <div>Amino Acid: <strong>{data.aminoAcid}</strong></div>
-          <div>pLDDT: <strong>{typeof data.plddt === 'number' ? data.plddt.toFixed(2) : data.plddt}</strong></div>
-          <div style={{ 
-            color: data.plddt > 90 ? '#05cd99' : data.plddt > 70 ? '#4318FF' : data.plddt > 50 ? '#FFCE20' : '#EE5D50',
-            fontWeight: 500,
-            marginTop: 4
-          }}>
-            {data.confidence}
-          </div>
-        </div>
-      );
-    }
-    return null;
-  };
-
   return (
     <div className="card" id="plddt-metrics-card">
       <div className="card__header">
@@ -74,32 +90,42 @@ export default function PldtMetrics({ plddtData, sequence }) {
             ❤️
           </span>
           pLDDT Score
-          <span style={{ fontSize: 12, color: 'var(--text-muted)', fontWeight: 400, marginLeft: 4 }}>ⓘ</span>
+          <span
+            style={{ fontSize: 12, color: 'var(--text-muted)', fontWeight: 400, marginLeft: 4 }}
+          >
+            ⓘ
+          </span>
         </div>
         <div className="card__actions">
-          <button className="card__action-btn" title="Calendar">📅</button>
-          <button className="card__action-btn" title="More">⋮</button>
+          <button className="card__action-btn" title="Calendar">
+            📅
+          </button>
+          <button className="card__action-btn" title="More">
+            ⋮
+          </button>
         </div>
       </div>
 
       <div className="card__body">
         {/* Validation Check */}
         {perResidue.length > 0 && (
-          <div style={{ 
-            display: 'flex', 
-            alignItems: 'center', 
-            gap: 6, 
-            marginBottom: 12,
-            padding: '8px 12px',
-            background: isValidated ? 'rgba(5, 205, 153, 0.1)' : 'rgba(238, 93, 80, 0.1)',
-            borderRadius: 6,
-            color: isValidated ? 'var(--success)' : 'var(--danger)',
-            fontSize: 13,
-            fontWeight: 500
-          }}>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 6,
+              marginBottom: 12,
+              padding: '8px 12px',
+              background: isValidated ? 'rgba(5, 205, 153, 0.1)' : 'rgba(238, 93, 80, 0.1)',
+              borderRadius: 6,
+              color: isValidated ? 'var(--success)' : 'var(--danger)',
+              fontSize: 13,
+              fontWeight: 500,
+            }}
+          >
             <span>{isValidated ? '✓' : '⚠️'}</span>
             <span>
-              {isValidated 
+              {isValidated
                 ? `Validation Passed: PDB array size (${perResidue.length}) matches sequence length (${sequenceLength}).`
                 : `Validation Failed: PDB array size (${perResidue.length}) does not match sequence length (${sequenceLength}).`}
             </span>
@@ -126,7 +152,10 @@ export default function PldtMetrics({ plddtData, sequence }) {
 
         {/* Recharts Area Chart */}
         {chartData.length > 0 ? (
-          <div className="plddt-metrics__chart" style={{ height: 280, width: '100%', marginTop: 20 }}>
+          <div
+            className="plddt-metrics__chart"
+            style={{ height: 280, width: '100%', marginTop: 20 }}
+          >
             <ResponsiveContainer width="100%" height="100%">
               <AreaChart data={chartData} margin={{ top: 5, right: 0, left: -20, bottom: 0 }}>
                 <defs>
@@ -136,28 +165,28 @@ export default function PldtMetrics({ plddtData, sequence }) {
                   </linearGradient>
                 </defs>
                 <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="#E9EDF7" />
-                <XAxis 
-                  dataKey="residueIndex" 
-                  tick={{ fontSize: 10, fill: '#A3AED0' }} 
-                  axisLine={false} 
+                <XAxis
+                  dataKey="residueIndex"
+                  tick={{ fontSize: 10, fill: '#A3AED0' }}
+                  axisLine={false}
                   tickLine={false}
                   minTickGap={20}
                 />
-                <YAxis 
-                  domain={[0, 100]} 
+                <YAxis
+                  domain={[0, 100]}
                   ticks={[0, 25, 50, 75, 100]}
-                  tick={{ fontSize: 10, fill: '#A3AED0' }} 
-                  axisLine={false} 
+                  tick={{ fontSize: 10, fill: '#A3AED0' }}
+                  axisLine={false}
                   tickLine={false}
                 />
                 <RechartsTooltip content={<CustomTooltip />} />
-                <Area 
-                  type="monotone" 
-                  dataKey="plddt" 
-                  stroke="#1B2559" 
+                <Area
+                  type="monotone"
+                  dataKey="plddt"
+                  stroke="#1B2559"
                   strokeWidth={2}
-                  fillOpacity={1} 
-                  fill="url(#colorPlddt)" 
+                  fillOpacity={1}
+                  fill="url(#colorPlddt)"
                   activeDot={{ r: 4, strokeWidth: 0, fill: '#4318FF' }}
                 />
               </AreaChart>
@@ -172,10 +201,10 @@ export default function PldtMetrics({ plddtData, sequence }) {
               justifyContent: 'center',
               color: 'var(--text-muted)',
               fontSize: 13,
-              height: 200
+              height: 200,
             }}
           >
-             No data yet
+            No data yet
           </div>
         )}
 


### PR DESCRIPTION
## 📝 Description

This PR entirely revamps the [PldtMetrics](cci:1://file:///e:/D/Protly/frontend/src/components/PldtMetrics.jsx:11:0-188:1) component to provide verifiably mapped, granular "quality insights" to the user. It upgrades the visualization engine to `recharts`, enabling interactive per-residue tooltips, and introduces a critical UI validation banner to guarantee data integrity between the PDB structure output and the source sequence.

## 🛠️ Changes Made

*   **Migrated to Recharts:** Replaced `Chart.js` with `recharts` to render a high-fidelity data area chart without aggressively down-sampling the per-residue metrics.
*   **Interactive Tooltips:** Implemented a [CustomTooltip](cci:1://file:///e:/D/Protly/frontend/src/components/PldtMetrics.jsx:35:2-63:4) that dynamically renders the specific metadata for each point on the chart, including:
    *   The residue index (e.g., "Residue 42").
    *   The exact amino acid letter mappings (e.g., "Amino Acid: M").
    *   The localized pLDDT score.
    *   A color-coded confidence translation (Very High, Confident, Low, Very Low).
*   **Visual Data Validation:** Added an explicit array-size validation banner at the top of the metrics card. It dynamically verifies that `plddtData.per_residue.length === sequence.length`, rendering a success or warning UI lock to assure the user of data mapping integrity.
*   **Mean Visibility:** Maintained and explicitly styled the overall model average pLDDT confidence indicator snippet for quick glanceability.

## ✅ Acceptance Criteria Completed

- [x] Render the overall Model Confidence (plDDT mean).
- [x] Implement a per-residue confidence chart using `recharts`.
- [x] Build interactable tooltips tracing back to individual residues.
- [x] Add a visual validation checking that the size of the array matches the length of the PDB structure successfully.

closes #25 